### PR TITLE
土日の場合に処理スキップされない件の修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Client } from 'notion_sdk'
 import dayjs from 'dayjs'
-import { okMessage, ngMessage } from './util.ts'
+import { okMessage, ngMessage, isTarget } from './util.ts'
 import { Slack } from './slack.ts'
 import { fetchSettings, fetchPage, createPage, updatePrevId } from './notion.ts'
 
@@ -24,25 +24,11 @@ const main = async () => {
       }
     }
 
-    // 実行対象が今日・明日のものだけを取得
-    if (
-      setting.runAt.format('YYYYMMDD') !== dayjs().format('YYYYMMDD') &&
-      setting.runAt.format('YYYYMMDD') !== dayjs().add(1, 'day').format('YYYYMMDD')
-    ) {
+    // TODO: 祝日機能の追加
+    if (!isTarget(setting.runAt.format('YYYY-MM-DD'), dayjs().format('YYYY-MM-DD'), prevRunAt?.format('YYYY-MM-DD'), true)) {
       continue
     }
-    console.log(
-      !prevRunAt ? 'not set' : prevRunAt.format('YYYY-MM-DD HH:mm'),
-      ' <=> ',
-      setting.runAt.format('YYYY-MM-DD HH:mm'),
-      'isSame = ',
-      prevRunAt !== null && setting.runAt.format('YYYYMMDDHHmm') === prevRunAt.format('YYYYMMDDHHmm'),
-    )
-    // 日付と1つ前のIDから該当のページがすでに作成済みかどうか判定する
-    if (prevRunAt !== null && setting.runAt.format('YYYYMMDDHHmm') === prevRunAt.format('YYYYMMDDHHmm')) {
-      console.log('[SKIP]page is already exist.')
-      continue
-    }
+
     const title = `${setting.title} ${setting.runAt.format('YYYY-MM-DD')}`
 
     // テンプレートページを取得・整形

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from 'testing/asserts.ts'
-import { okMessage, ngMessage } from './util.ts'
+import {okMessage, ngMessage, isTarget} from './util.ts'
 
 Deno.test('okMessage', () => {
   const res = okMessage('dummy')
@@ -9,4 +9,67 @@ Deno.test('okMessage', () => {
 Deno.test('ngMessage', () => {
   const res = ngMessage('dummyMsg', 'dummyTitle')
   assertEquals(res.text, '⛔ dummyMsg\n[ *title:dummyTitle* ]')
+})
+
+// 休日スキップフラグON
+Deno.test('休日スキップフラグがON 実行日が休日 作成予定日が休日 処理がスキップされること', () => {
+  const res = isTarget('20220101', '20220101', null, true)
+  assertEquals(res, false)
+})
+
+Deno.test('休日スキップフラグがON 実行日が平日 作成予定日が平日 作成予定日の2日前 処理がスキップされること', () => {
+  const res = isTarget('20220107', '20220105', null, true)
+  assertEquals(res, false)
+})
+
+Deno.test('休日スキップフラグがON 実行日が平日 作成予定日が平日 作成予定日の1日前 処理がスキップされないこと', () => {
+  const res = isTarget('20220107', '20220106', null, true)
+  assertEquals(res, true)
+})
+
+Deno.test('休日スキップフラグがON 実行日が平日 作成予定日が休日 作成予定日の1日後 処理がスキップされること', () => {
+  const res = isTarget('20220107', '20220108', null, true)
+  assertEquals(res, false)
+})
+
+// 休日スキップフラグOFF
+Deno.test('休日スキップフラグがOFF 実行日が休日 作成予定日が平日 作成予定日の1日前 処理がスキップされないこと', () => {
+  const res = isTarget('20220110', '20220109', null, false)
+  assertEquals(res, true)
+})
+
+Deno.test('休日スキップフラグがOFF 実行日が休日 作成予定日が休日 処理がスキップされないこと', () => {
+  const res = isTarget('20220101', '20220101', null, false)
+  assertEquals(res, true)
+})
+
+Deno.test('休日スキップフラグがOFF 実行日が平日 作成予定日が平日 作成予定日の2日前 処理がスキップされること', () => {
+  const res = isTarget('20220107', '20220105', null, false)
+  assertEquals(res, false)
+})
+
+Deno.test('休日スキップフラグがOFF 実行日が平日 作成予定日が平日 作成予定日の1日前 処理がスキップされないこと', () => {
+  const res = isTarget('20220107', '20220106', null, false)
+  assertEquals(res, true)
+})
+
+Deno.test('休日スキップフラグがOFF 実行日が平日 作成予定日が休日 作成予定日の1日後 処理がスキップされること', () => {
+  const res = isTarget('20220107', '20220108', null, false)
+  assertEquals(res, false)
+})
+
+Deno.test('休日スキップフラグがOFF 実行日が休日 作成予定日が平日 作成予定日の1日前 処理がスキップされないこと', () => {
+  const res = isTarget('20220110', '20220109', null, false)
+  assertEquals(res, true)
+})
+
+// その他テスト
+Deno.test('前回実行日と次回実行日が同じ場合 作成予定日の1日前 処理がスキップされること', () => {
+  const res = isTarget('20220107', '20220106', '20220107', false)
+  assertEquals(res, false)
+})
+
+Deno.test('前回実行日がundefinedの場合 作成予定日の1日前 処理がスキップされないこと', () => {
+  const res = isTarget('20220107', '20220106', undefined, false)
+  assertEquals(res, true)
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,31 @@
-export const okMessage = (text: string) => ({ text: `✅ ${text}` })
+import dayjs from 'dayjs'
+
+export const okMessage = (text: string) => ({text: `✅ ${text}`})
 export const ngMessage = (text: string, title: string) => ({
   text: [`⛔ ${text}`, `[ *title:${title}* ]`].join('\n'),
 })
+
+export const isTarget = (target: string, now: string, previous: string|null|undefined, skipHoliday: boolean): boolean => {
+  const t = dayjs(target)
+  const n = dayjs(now)
+  const p = !previous ? null : dayjs(previous)
+
+  if (skipHoliday && ([0, 6].includes(t.day()) || [0, 6].includes(n.day()))) {
+    console.log('[SKIP]today is holiday.')
+    return false
+  }
+
+  if (
+    t.format('YYYYMMDD') !== n.format('YYYYMMDD') &&
+    t.format('YYYYMMDD') !== n.add(1, 'day').format('YYYYMMDD')
+  ) {
+    console.log('[SKIP]day has not come yet.')
+    return false
+  }
+
+  if (p !== null && t.format('YYYYMMDD') === p.format('YYYYMMDD')) {
+    console.log('[SKIP]page is already exist.')
+    return false
+  }
+  return true
+}


### PR DESCRIPTION
fix: https://github.com/tosite/notion-page-repeater/issues/16

```diff  
diff --git a/src/index.ts b/src/index.ts
index 081b12e..89a3de5 100644
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const main = async () => {
     }
 
     // TODO: 祝日機能の追加
-    if (!isTarget(setting.runAt.format('YYYY-MM-DD'), dayjs().format('YYYY-MM-DD'), prevRunAt?.format('YYYY-MM-DD'), true)) {
+    if (!isTarget(setting.runAt.format('YYYY-MM-DD'), '2022-02-20', prevRunAt?.format('YYYY-MM-DD'), true)) {
       continue
     }
```

```  
➜  notion-page-repeater git:(fix-holiday-skip) ✗ make start
deno run -A --import-map ./import_map.json ./src/index.ts
Check file:///Users/n.teshima/ghq/github.com/tosite/notion-page-repeater/src/index.ts
==== start creating page ========
[SKIP]today is holiday.
```

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/24952964/154046153-796d993b-0fb5-46ef-9cd7-326350556f2a.png">

上記ローカルで動作を確認しました。