### PR TITLE
デバッグログを追加する

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ if (!settingDbId) {
 }
 
 const main = async () => {
-  console.log('==== start creating page ========')
+  console.log('==== start creating page =============')
   const settings = await fetchSettings(notion, settingDbId)
   for (const setting of settings.entries) {
     const prevPage = setting?.prevId ? await fetchPage(notion, setting.prevId) : null
@@ -39,7 +39,7 @@ const main = async () => {
     }
     console.log('  end.')
 
-    console.log('==== fetching template page ========')
+    console.log('==== fetching template page ==========')
     const templatePage = await fetchPage(notion, setting.templateId)
     if (!templatePage) {
       await slack.send(ngMessage('テンプレートページが見つかりませんでした', title)).catch(() => {})
@@ -95,7 +95,7 @@ const main = async () => {
         ),
       )
       .catch(() => {})
-    console.log('==== finish creating page =========')
+    console.log('==== finish creating page ============')
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ const main = async () => {
       console.log('[ERROR]template ID is empty.')
       continue
     }
+    console.log('  end.')
+
     console.log('==== fetching template page ========')
     const templatePage = await fetchPage(notion, setting.templateId)
     if (!templatePage) {
@@ -57,19 +59,18 @@ const main = async () => {
       console.log('[ERROR]template-params parse error.')
       continue
     }
+    console.log('  end.')
 
     console.log('==== sanitize template params ========')
-    const sanitizeParams = sanitizeProperties(templateParams, title)
-    const safeParams = sanitizeParams.safeParams
+    const safeParams = sanitizeProperties(templateParams, title)
 
     // テンプレートページを元に新しいページを作成する
     let newPageId = ''
     try {
       newPageId = await createPage(notion, setting, safeParams, parentDbId)
     } catch(e) {
-      console.log('==== raw keys ========', sanitizeParams.rawKeys)
-      console.log('==== safe keys ========', sanitizeParams.safeKeys)
-      throw e
+      console.log('[ERROR]properties cannot added.')
+      continue
     }
 
     if (newPageId === '') {
@@ -77,6 +78,7 @@ const main = async () => {
       console.log('[ERROR]Failed creating new page.')
       continue
     }
+    console.log('  end.')
 
     // 新しいページIDで設定を上書き
     await updatePrevId(notion, setting.id, newPageId)

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,9 @@ if (!settingDbId) {
 }
 
 const main = async () => {
+  console.log('==== start creating page ========')
   const settings = await fetchSettings(notion, settingDbId)
   for (const setting of settings.entries) {
-    console.log('==== start creating page ========')
     const prevPage = setting?.prevId ? await fetchPage(notion, setting.prevId) : null
     let prevRunAt = null
     if (prevPage !== null) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -107,6 +107,8 @@ export const parseSettingEntry = (id: string, properties: any): SettingEntry => 
   const templateId: string = parseText(properties['template_id'])
   const runHoliday = parseBool(properties['run_holiday'], false)
 
+  console.log(`  title = ${title}, span = ${span}, week = ${!weeks ? 'null' : weeks.join(", ")}, holiday = ${!runHoliday ? 'skip' : 'run'}`)
+
   return {
     id,
     runAt: parseNextRunAt(span, weeks, hour, min),

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -84,23 +84,10 @@ Deno.test('コピーできないパラメータが含まれる場合 サニタ�
     "rollup": {type: 'rollup', rollup: {type: 'date', date: 'null', function: 'earliest_date'}},
     "relation": {type: 'relation', relation: []},
   }
-  const rawKeys = [
-    '',
-    'created time => created_time',
-    'last edited time => last_edited_time',
-    'created by => created_by',
-    'last edited by => last_edited_by',
-    'formula => formula',
-    'rollup => rollup',
-    'relation => relation',
-  ].join("\n")
-  const safeKeys = [].join("\n")
 
   const res = sanitizeProperties(params, 'page title')
 
-  assertEquals(res.safeParams, {})
-  assertEquals(res.rawKeys, rawKeys)
-  assertEquals(res.safeKeys, safeKeys)
+  assertEquals(res, {})
 })
 
 Deno.test('コピーできるパラメータが含まれる場合 サニタイズされること', () => {
@@ -115,26 +102,12 @@ Deno.test('コピーできるパラメータが含まれる場合 サニタイ�
     "safe param": {type: 'multi_select', multi_select: [{name: 'select', color: 'orange'}]},
     "title": {type: 'title', title: [{type: 'text', text: {'content': 'meeting title'}, plain_text: 'meeting title'}]},
   }
-  const rawKeys = [
-    '',
-    'created time => created_time',
-    'last edited time => last_edited_time',
-    'created by => created_by',
-    'last edited by => last_edited_by',
-    'formula => formula',
-    'rollup => rollup',
-    'relation => relation',
-    'safe param => multi_select',
-    'title => title',
-  ].join("\n")
-  const safeKeys = ['', 'safe param => multi_select', 'title => title'].join("\n")
   const expect = {
     "safe param": {type: 'multi_select', multi_select: [{name: 'select', color: 'orange'}]},
-    "title": {type: 'title', title: [{type: 'text', text: {'content': 'page title'}, plain_text: 'page title'}]}  }
+    "title": {type: 'title', title: [{type: 'text', text: {'content': 'page title'}, plain_text: 'page title'}]}
+  }
 
   const res = sanitizeProperties(params, 'page title')
 
-  assertEquals(res.safeParams, expect)
-  assertEquals(res.rawKeys, rawKeys)
-  assertEquals(res.safeKeys, safeKeys)
+  assertEquals(res, expect)
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -48,9 +48,9 @@ export const sanitizeProperties = (templateParams: { [index: string]: any }, tit
   let safeKeys = []
   for (const [key, value] of Object.entries(templateParams)) {
     const property: { type: string } = value
-    rawKeys.push(`${key} => ${property?.type}`)
+    rawKeys.push(`'${key}' => ${property?.type}`)
     if (!unsafeTypes.includes(property?.type)) {
-      safeKeys.push(`${key} => ${property?.type}`)
+      safeKeys.push(`'${key}' => ${property?.type}`)
       safeParams[key] = property
       if (property?.type === 'title') {
         safeParams[key]['title'][0]['plain_text'] = title

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,13 +1,5 @@
 import dayjs from 'dayjs'
 
-export interface SanitizeProperties {
-  rawKeys: string
-  safeKeys: string
-  safeParams: {
-    [index: string]: any
-  }
-}
-
 export const okMessage = (text: string) => ({text: `✅ ${text}`})
 export const ngMessage = (text: string, title: string) => ({
   text: [`⛔ ${text}`, `[ *title:${title}* ]`].join('\n'),
@@ -41,7 +33,7 @@ export const isTarget = (target: string, now: string, previous: string | null | 
   return true
 }
 
-export const sanitizeProperties = (templateParams: { [index: string]: any }, title: string): SanitizeProperties => {
+export const sanitizeProperties = (templateParams: { [index: string]: any }, title: string): { [index: string]: any } => {
   const unsafeTypes = [
     'created_time',
     'last_edited_time',
@@ -52,13 +44,13 @@ export const sanitizeProperties = (templateParams: { [index: string]: any }, tit
     'relation',
   ]
   let safeParams: { [index: string]: any } = {}
-  let rawKeys = ''
-  let safeKeys = ''
+  let rawKeys = []
+  let safeKeys = []
   for (const [key, value] of Object.entries(templateParams)) {
     const property: { type: string } = value
-    rawKeys += `\n${key} => ${property?.type}`
+    rawKeys.push(`${key} => ${property?.type}`)
     if (!unsafeTypes.includes(property?.type)) {
-      safeKeys += `\n${key} => ${property?.type}`
+      safeKeys.push(`${key} => ${property?.type}`)
       safeParams[key] = property
       if (property?.type === 'title') {
         safeParams[key]['title'][0]['plain_text'] = title
@@ -66,5 +58,6 @@ export const sanitizeProperties = (templateParams: { [index: string]: any }, tit
       }
     }
   }
-  return {rawKeys: rawKeys, safeKeys: safeKeys, safeParams: safeParams}
+  console.log(`  raw keys = ${rawKeys.join(', ')}, safe keys = ${safeKeys.join(', ')}`)
+  return safeParams
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,6 +18,9 @@ export const isTarget = (target: string, now: string, previous: string | null | 
   const n = dayjs(now)
   const p = !previous ? null : dayjs(previous)
 
+  const f = 'YYYY-MM-DD HH:mm:ss'
+  console.log(`  isTarget: today = ${n.format(f)}, target = ${t.format(f)}, previous = ${!p ? 'null' : p.format(f)}`)
+
   if (skipHoliday && ([0, 6].includes(t.day()) || [0, 6].includes(n.day()))) {
     console.log('[SKIP]today is holiday.')
     return false

--- a/src/util.ts
+++ b/src/util.ts
@@ -58,6 +58,7 @@ export const sanitizeProperties = (templateParams: { [index: string]: any }, tit
       }
     }
   }
-  console.log(`  raw keys = ${rawKeys.join(', ')}, safe keys = ${safeKeys.join(', ')}`)
+  console.log(`  raw keys  = ${rawKeys.join(', ')}`)
+  console.log(`  safe keys = ${safeKeys.join(', ')}`)
   return safeParams
 }


### PR DESCRIPTION
```  
➜  notion-page-repeater git:(add-debug) ✗ make start
deno run -A --import-map ./import_map.json ./src/index.ts
Check file:///Users/n.teshima/ghq/github.com/tosite/notion-page-repeater/src/index.ts
==== start creating page ========
  title = 議事録, span = weekly, week = Fri, Wed, Mon, holiday = skip
  isTarget: today = 2022-02-21 00:00:00, target = 2022-02-21 00:00:00, previous = null
  end.
==== fetching template page ========
  end.
==== sanitize template params ========
  raw keys  = 'Datetime' => date, 'Tags' => multi_select, 'formula' => formula, 'rollup' => rollup, 'last edited time' => last_edited_time, 'created by' => created_by, 'last edited by' => last_edited_by, 'relation' => relation, 'Property' => rich_text, 'created time' => created_time, 'Name' => title
  safe keys = 'Datetime' => date, 'Tags' => multi_select, 'Property' => rich_text, 'Name' => title
  end.
==== finish creating page =========
```

```  
➜  notion-page-repeater git:(add-debug) ✗ make start
deno run -A --import-map ./import_map.json ./src/index.ts
==== start creating page ========
  title = 議事録, span = weekly, week = Fri, Wed, Mon, holiday = skip
  isTarget: today = 2022-02-21 00:00:00, target = 2022-02-21 00:00:00, previous = 2022-02-21 00:00:00
[SKIP]page is already exist.
```

実行時ログを追加することでデバッグしやすくします。